### PR TITLE
Forum update view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
   - "3.6"
 
 env:
-  - DJANGO_SECRET_KEY='testSECRETkey$&!'
-  - PIP_USE_MIRRORS=true
+  global:
+    - DJANGO_SECRET_KEY='testSECRETkey$&!'
+    - PIP_USE_MIRRORS=true
 
 install:
   - pip install -r requirements.txt

--- a/forum/forms.py
+++ b/forum/forms.py
@@ -1,0 +1,9 @@
+from django.forms import ModelForm
+
+from .models import Forum
+
+
+class ForumUpdateForm(ModelForm):
+    class Meta:
+        model = Forum
+        fields = ('moderators',)

--- a/forum/mixins.py
+++ b/forum/mixins.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
+
+
+class ModeratorRequiredMixin(LoginRequiredMixin, ABC):
+    @abstractmethod
+    def get_forum(self):
+        pass
+
+    def dispatch(self, request, *args, **kwargs):
+        user = request.user
+        forum = self.get_forum()
+        if not forum.moderators.filter(username=user.username).exists():
+            return redirect(forum.get_absolute_url())
+
+        return super().dispatch(request, *args, **kwargs)

--- a/forum/templates/forum/forum_form.html
+++ b/forum/templates/forum/forum_form.html
@@ -1,0 +1,31 @@
+{% extends 'layout.html' %}
+{% load humanize %}
+
+{% block meta_title %}{{ object.slug }} - Update{% endblock %}
+{% block meta_description %}Subreddit description{% endblock %}
+{% block meta_og_title %}{{ object.slug }} - Update{% endblock %}
+{% block meta_og_description %}Subreddit description{% endblock %}
+
+{% block extra_style %}
+    <style>
+        div.post-item {
+            border: 1px solid #000000;
+            padding: 0em 2em;
+        }
+    </style>
+{% endblock %}
+
+{% block body %}
+    <section>
+        <h1>{{ object.slug }}</h1>
+        <p>Subreddit description</p>
+    </section>
+
+    <section>
+        <form action="" method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" value="Update" />
+        </form>
+    </section>
+{% endblock %}

--- a/forum/tests/test_views.py
+++ b/forum/tests/test_views.py
@@ -19,6 +19,12 @@ class ForumListViewTestCase(TestCase):
         self.assertTrue(True)
 
 
+class ForumUpdateViewTestCase(TestCase):
+    def test_200(self):
+        # TODO
+        self.assertTrue(True)
+
+
 class PostDetailViewTestCase(TestCase):
     def test_200(self):
         # TODO

--- a/forum/urls.py
+++ b/forum/urls.py
@@ -3,11 +3,11 @@ from django.urls import path
 from .views import (
     ForumDetailView,
     ForumListView,
+    ForumUpdateView,
     PostDetailView,
     CommentDetailView,
     CommentUpvoteView,
     CommentDownvoteView,
-    # Adding new paths 
     PostUpvoteView, 
     PostDownvoteView
 )
@@ -20,13 +20,15 @@ urlpatterns = [
     path('comments/<uuid:pk>/downvote/',
          CommentDownvoteView.as_view(),
          name='comment_downvote'),
-#  Adding post_upvote and down_vote paths
     path('posts/<uuid:pk>/upvote/',
          PostUpvoteView.as_view(),
          name='post_upvote'),
     path('posts/<uuid:pk>/downvote/',
          PostDownvoteView.as_view(),
          name='post_downvote'),
+    path('<slug:slug>/update/',
+         ForumUpdateView.as_view(),
+         name='forum_moderators_add'),
     path('<slug:slug>/',
          ForumDetailView.as_view(),
          name='forum_detail'),

--- a/forum/views.py
+++ b/forum/views.py
@@ -1,8 +1,12 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic.detail import DetailView
+from django.views.generic.edit import UpdateView
 from django.views.generic.list import ListView
 from django.views import View
 from django.shortcuts import get_object_or_404, redirect
+
+from .mixins import ModeratorRequiredMixin
+from .forms import ForumUpdateForm
 
 from .models import (
     Forum,
@@ -21,6 +25,14 @@ class ForumDetailView(DetailView):
 
 class ForumListView(ListView):
     model = Forum
+
+
+class ForumUpdateView(ModeratorRequiredMixin, UpdateView):
+    model = Forum
+    form_class = ForumUpdateForm
+
+    def get_forum(self):
+        return self.get_object()
 
 
 class PostDetailView(DetailView):


### PR DESCRIPTION
This adds a new page to edit a `Forum`. Currently, the only field you can edit on the `Forum` are the `moderators`.

This PR will show you how to use the `dispatch` view method to redirect users away from views they shouldn't see. In this case, only moderators who belong to the forum should be able to edit it. All other Users will be redirected to the forum detail page by default.